### PR TITLE
Update index.php

### DIFF
--- a/PHPSample/index.php
+++ b/PHPSample/index.php
@@ -18,7 +18,7 @@
     // end runnable specific code snipit ##########################//
     intuit.ipp.anywhere.setup({
         menuProxy: '',
-        grantUrl: 'http://'+parser.hostname+'/PHPSample/oauth.php?start=t' 
+        grantUrl: 'http://'+window.location.hostname+'/PHPSample/oauth.php?start=t' 
         // outside runnable you can point directly to the oauth.php page
     });
   </script>


### PR DESCRIPTION
Cross-browser compatibility, 
Fails in IE11 and sends back a missing hostname which causes https://appcenter.intuit.com/Connect/SessionStart to fail